### PR TITLE
Don't add generated classes to class registry

### DIFF
--- a/marshmallow_factory/__init__.py
+++ b/marshmallow_factory/__init__.py
@@ -9,8 +9,9 @@ def schema(_schema_dict=None, **kwargs):
     for key, value in _schema_dict.items():
         if isinstance(value, dict):
             _schema_dict[key] = nested_schema(value)
-
-    return SchemaMeta('AnonymousSchema', (Schema,), _schema_dict)
+    # Passing empty string prevents class from getting added
+    # to marshmallow's class registry, thus saving memory
+    return SchemaMeta(str(''), (Schema,), _schema_dict)
 
 
 schema_factory = schema  # alternative import name


### PR DESCRIPTION
You can prevent generated classes from getting added to marshmallow's type registry by passing an empty string as the class name. This results in some memory savings.